### PR TITLE
Remove links to events page, add link to application library

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -4,14 +4,12 @@ main:
     url: /about
   - title: "Posts and publications"
     url: /publications
-  - title: "Upcoming events"
-    url: /events
+  # - title: "Upcoming events"
+  #   url: /events
   - title: "FAQ"
     url: /faq
-  # - title: "Github"
-  #   url: https://github.com/FiQCI/fiqci.github.io
-  # - title: "About"
-  #   url: https://mmistakes.github.io/minimal-mistakes/about/
+  - title: "Application Library"
+    url: https://nordiquest.net/application-library/
   # - title: "Sample Posts"
   #   url: /year-archive/
   # - title: "Sample Collections"

--- a/_pages/landing-page.md
+++ b/_pages/landing-page.md
@@ -30,7 +30,7 @@ feature_row:
     title: "FAQ"
     excerpt: "Frequently asked questions"
     url: "/faq"
-    btn_class: "btn-primary"
+    btn_class: "btn--primary"
     btn_label: "Learn more"
 ---
 

--- a/_pages/landing-page.md
+++ b/_pages/landing-page.md
@@ -20,24 +20,18 @@ feature_row:
     url: "/about"
     btn_class: "btn--primary"
     btn_label: "Learn more"      
-  - image_path: /assets/images/events-icon.png
-    title: "Upcoming events"
-    excerpt: "Upcoming events hosted by NordIQuEst"
-    url: "/events"
-    btn_class: "btn--primary"
-    btn_label: "Learn more"
   - image_path: /assets/images/posts-icon.png
     title: "Posts and publications"
     excerpt: "Blog posts, publications, and other material of interest"
     url: "/publications"
     btn_class: "btn--primary"
     btn_label: "Learn more"
-  - image_path: /assets/images/posts-icon.png
+  - image_path: /assets/images/events-icon.png
     title: "FAQ"
     excerpt: "Frequently asked questions"
     url: "/faq"
     btn_class: "btn-primary"
-    btn_label: "FAQ"
+    btn_label: "Learn more"
 ---
 
 {% include feature_row id="intro" type="center" %}


### PR DESCRIPTION
https://github.com/NordIQuEst/nordiquest.github.io/pull/18 by @tiggi Added an additional entry to the landing page named FAQ. This caused the landing page to have 2 rows instead of 1, including the events page. To solve this, the events page was removed from the landing page and the navbar. The events page was empty regardless and it can still be reached via the `\events` path. 

Additionally, a link to the Application library was added to the nav bar. 

